### PR TITLE
chore: add debug support for provider

### DIFF
--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -60,7 +60,7 @@ func testAccCheckResourceIntegrationExists(resourceName, organizationName string
 		for _, org := range orgs {
 			if org.Name == organizationName {
 				organizationID = org.ID
-				return nil
+				break
 			}
 		}
 		if organizationID == "" {
@@ -68,6 +68,10 @@ func testAccCheckResourceIntegrationExists(resourceName, organizationName string
 		}
 
 		integrations, _, err := client.Integrations.List(context.Background(), organizationID)
+		if err != nil {
+			return err
+		}
+
 		for t, id := range integrations {
 			if id == rs.Primary.ID {
 				integration = &snyk.Integration{

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"flag"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 
@@ -9,8 +11,17 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
-	_ = providerserver.Serve(ctx, provider.New, providerserver.ServeOpts{
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with debug support")
+	flag.Parse()
+
+	err := providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{
 		Address: "registry.terraform.io/pavel-snyk/snyk",
+		Debug:   debugMode,
 	})
+
+	if err != nil {
+		log.Fatal(err.Error())
+	}
 }


### PR DESCRIPTION
This PR adds debug support for provider (e.g. delve) by using `-debug` flag.