### PR TITLE
chore: set provider version via ldflags when releasing

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -26,6 +26,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+    ldflags:
+      - "-s -w -X main.version={{.Version}}"
     mod_timestamp: '{{ .CommitTimestamp }}'
 
 checksum:

--- a/internal/validators/string_not_empty_test.go
+++ b/internal/validators/string_not_empty_test.go
@@ -19,19 +19,19 @@ func TestNotEmptyStringValidatorValidator(t *testing.T) {
 		expectError bool
 	}
 	tests := map[string]testCase{
-		"unknown String": {
+		"unknown_string": {
 			val:         types.String{Unknown: true},
 			expectError: false,
 		},
-		"null String": {
+		"null_string": {
 			val:         types.String{Null: true},
 			expectError: true,
 		},
-		"empty String": {
+		"empty_string": {
 			val:         types.String{Value: ""},
 			expectError: true,
 		},
-		"non-empty String": {
+		"non-empty_string": {
 			val:         types.String{Value: "test string"},
 			expectError: false,
 		},

--- a/main.go
+++ b/main.go
@@ -10,13 +10,17 @@ import (
 	"github.com/pavel-snyk/terraform-provider-snyk/internal/provider"
 )
 
+var (
+	version = "dev"
+)
+
 func main() {
 	var debugMode bool
 
 	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with debug support")
 	flag.Parse()
 
-	err := providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{
+	err := providerserver.Serve(context.Background(), provider.New(version), providerserver.ServeOpts{
 		Address: "registry.terraform.io/pavel-snyk/snyk",
 		Debug:   debugMode,
 	})


### PR DESCRIPTION
This PR adds `version` variable passing to user-agent header.

The version value is:
- `dev` for development
- `testacc` for acceptance tests
- release version set by ldflags (i.a `0.4.1`)