### PR TITLE
fix(resource/snyk_integration): add credential validator for type

### DIFF
--- a/internal/provider/data_source_project.go
+++ b/internal/provider/data_source_project.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pavel-snyk/snyk-sdk-go/snyk"
 
-	"github.com/pavel-snyk/terraform-provider-snyk/internal/validators"
+	"github.com/pavel-snyk/terraform-provider-snyk/internal/validator"
 )
 
 var _ datasource.DataSource = (*projectDataSource)(nil)
@@ -39,7 +39,7 @@ func (d *projectDataSource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Dia
 				Description: "The name of the project.",
 				Required:    true,
 				Validators: []tfsdk.AttributeValidator{
-					validators.NotEmptyString(),
+					validator.NotEmptyString(),
 				},
 				Type: types.StringType,
 			},
@@ -47,7 +47,7 @@ func (d *projectDataSource) GetSchema(_ context.Context) (tfsdk.Schema, diag.Dia
 				Description: "The ID of the organization that the project belongs to.",
 				Required:    true,
 				Validators: []tfsdk.AttributeValidator{
-					validators.NotEmptyString(),
+					validator.NotEmptyString(),
 				},
 				Type: types.StringType,
 			},

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/pavel-snyk/snyk-sdk-go/snyk"
+
+	"github.com/pavel-snyk/terraform-provider-snyk/internal/validator"
 )
 
 var _ resource.Resource = (*integrationResource)(nil)
@@ -195,27 +197,8 @@ func (r *integrationResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.D
 				Required:      true,
 				PlanModifiers: tfsdk.AttributePlanModifiers{resource.RequiresReplace()},
 				Validators: []tfsdk.AttributeValidator{
-					stringvalidator.OneOf([]string{
-						snyk.ACRIntegrationType,
-						snyk.ArtifactoryCRIntegrationType,
-						snyk.AzureReposIntegrationType,
-						snyk.BitBucketCloudIntegrationType,
-						snyk.BitBucketConnectAppIntegrationType,
-						snyk.BitBucketServerIntegrationType,
-						snyk.DigitalOceanCRIntegrationType,
-						snyk.DockerHubIntegrationType,
-						snyk.ECRIntegrationType,
-						snyk.GCRIntegrationType,
-						snyk.GitHubIntegrationType,
-						snyk.GitHubCRIntegrationType,
-						snyk.GitHubEnterpriseIntegrationType,
-						snyk.GitLabIntegrationType,
-						snyk.GitLabCRIntegrationType,
-						snyk.GoogleArtifactCRIntegrationType,
-						snyk.HarborCRIntegrationType,
-						snyk.NexusCRIntegrationType,
-						snyk.QuayCRIntegrationType,
-					}...),
+					stringvalidator.OneOf(validator.AllowedIntegrationTypes()...),
+					validator.RequiresConfiguredCredentials(),
 				},
 				Type: types.StringType,
 			},

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -197,6 +198,27 @@ func (r *integrationResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.D
 				PlanModifiers: tfsdk.AttributePlanModifiers{resource.RequiresReplace()},
 				Validators: []tfsdk.AttributeValidator{
 					validators.NotEmptyString(),
+					stringvalidator.OneOf([]string{
+						snyk.ACRIntegrationType,
+						snyk.ArtifactoryCRIntegrationType,
+						snyk.AzureReposIntegrationType,
+						snyk.BitBucketCloudIntegrationType,
+						snyk.BitBucketConnectAppIntegrationType,
+						snyk.BitBucketServerIntegrationType,
+						snyk.DigitalOceanCRIntegrationType,
+						snyk.DockerHubIntegrationType,
+						snyk.ECRIntegrationType,
+						snyk.GCRIntegrationType,
+						snyk.GitHubIntegrationType,
+						snyk.GitHubCRIntegrationType,
+						snyk.GitHubEnterpriseIntegrationType,
+						snyk.GitLabIntegrationType,
+						snyk.GitLabCRIntegrationType,
+						snyk.GoogleArtifactCRIntegrationType,
+						snyk.HarborCRIntegrationType,
+						snyk.NexusCRIntegrationType,
+						snyk.QuayCRIntegrationType,
+					}...),
 				},
 				Type: types.StringType,
 			},

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	"github.com/pavel-snyk/snyk-sdk-go/snyk"
-
-	"github.com/pavel-snyk/terraform-provider-snyk/internal/validators"
 )
 
 var _ resource.Resource = (*integrationResource)(nil)
@@ -197,7 +195,6 @@ func (r *integrationResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.D
 				Required:      true,
 				PlanModifiers: tfsdk.AttributePlanModifiers{resource.RequiresReplace()},
 				Validators: []tfsdk.AttributeValidator{
-					validators.NotEmptyString(),
 					stringvalidator.OneOf([]string{
 						snyk.ACRIntegrationType,
 						snyk.ArtifactoryCRIntegrationType,

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -24,10 +24,6 @@ func TestAccResourceIntegration_basic(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccResourceIntegrationConfig(organizationName, groupID, ""),
-				ExpectError: regexp.MustCompile("Wrong credentials for given integration type"),
-			},
-			{
 				Config: testAccResourceIntegrationConfig(organizationName, groupID, token),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourceIntegrationExists("snyk_integration.test", organizationName, &integration),

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -75,7 +75,7 @@ func TestAccResourceIntegration_invalidTypes(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceIntegrationConfigWithTypes(organizationName, groupID, ""),
-				ExpectError: regexp.MustCompile("string must not be empty"),
+				ExpectError: regexp.MustCompile("Value must be one of"),
 			},
 			{
 				Config:      testAccResourceIntegrationConfigWithTypes(organizationName, groupID, "non-existing-type"),

--- a/internal/provider/resource_organization.go
+++ b/internal/provider/resource_organization.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pavel-snyk/snyk-sdk-go/snyk"
 
-	"github.com/pavel-snyk/terraform-provider-snyk/internal/validators"
+	"github.com/pavel-snyk/terraform-provider-snyk/internal/validator"
 )
 
 var _ resource.Resource = (*organizationResource)(nil)
@@ -47,7 +47,7 @@ func (r *organizationResource) GetSchema(_ context.Context) (tfsdk.Schema, diag.
 				Required:    true,
 				Type:        types.StringType,
 				Validators: []tfsdk.AttributeValidator{
-					validators.NotEmptyString(),
+					validator.NotEmptyString(),
 				},
 			},
 		},

--- a/internal/validator/credential_requires_configured.go
+++ b/internal/validator/credential_requires_configured.go
@@ -1,0 +1,281 @@
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/pavel-snyk/snyk-sdk-go/snyk"
+)
+
+var _ tfsdk.AttributeValidator = requiredConfiguredCredentialsValidator{}
+
+const (
+	attributePassword    = "password"
+	attributeRegion      = "region"
+	attributeRegistryURL = "registry_url"
+	attributeRoleARN     = "role_arn"
+	attributeToken       = "token"
+	attributeURL         = "url"
+	attributeUsername    = "username"
+)
+
+type requiredConfiguredCredentialsValidator struct{}
+
+func (validator requiredConfiguredCredentialsValidator) Description(_ context.Context) string {
+	return "Ensure that integration is correctly configured"
+}
+
+func (validator requiredConfiguredCredentialsValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+func (validator requiredConfiguredCredentialsValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
+	t := request.AttributeConfig.(types.String)
+
+	if t.IsUnknown() {
+		return
+	}
+
+	typePath := path.MatchRoot("type").String()
+	configuredPath := request.AttributePathExpression.String()
+
+	if typePath != configuredPath {
+		response.Diagnostics.AddAttributeError(
+			request.AttributePath,
+			validator.Description(ctx),
+			"Validator must be applied for integration 'type' only.",
+		)
+		return
+	}
+
+	switch t.Value {
+	case snyk.ACRIntegrationType:
+		username, diags := getAttributeValue(ctx, attributeUsername, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		password, diags := getAttributeValue(ctx, attributePassword, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		registryURL, diags := getAttributeValue(ctx, attributeRegistryURL, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		if username.IsNull() || username.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributeUsername,
+					snyk.ACRIntegrationType,
+				),
+			)
+		}
+
+		if password.IsNull() || password.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributePassword,
+					snyk.ACRIntegrationType,
+				),
+			)
+		}
+
+		if registryURL.IsNull() || registryURL.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributeRegistryURL,
+					snyk.ACRIntegrationType,
+				),
+			)
+		}
+
+	case snyk.BitBucketCloudIntegrationType:
+		username, diags := getAttributeValue(ctx, attributeUsername, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		password, diags := getAttributeValue(ctx, attributePassword, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		if username.IsNull() || username.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributeUsername,
+					snyk.BitBucketCloudIntegrationType,
+				),
+			)
+		}
+
+		if password.IsNull() || password.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributePassword,
+					snyk.BitBucketCloudIntegrationType,
+				),
+			)
+		}
+
+	case snyk.BitBucketServerIntegrationType:
+		username, diags := getAttributeValue(ctx, attributeUsername, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		password, diags := getAttributeValue(ctx, attributePassword, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		url, diags := getAttributeValue(ctx, attributeURL, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		if username.IsNull() || username.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributeUsername,
+					snyk.BitBucketServerIntegrationType,
+				),
+			)
+		}
+
+		if password.IsNull() || password.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributePassword,
+					snyk.BitBucketServerIntegrationType,
+				),
+			)
+		}
+
+		if url.IsNull() || url.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributeURL,
+					snyk.BitBucketServerIntegrationType,
+				),
+			)
+		}
+
+	case snyk.GitHubIntegrationType:
+		token, diags := getAttributeValue(ctx, attributeToken, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		if token.IsNull() || token.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributeToken,
+					snyk.GitHubIntegrationType,
+				),
+			)
+		}
+
+	case snyk.GitLabIntegrationType:
+		token, diags := getAttributeValue(ctx, attributeToken, request)
+		response.Diagnostics.Append(diags...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		if token.IsNull() || token.Value == "" {
+			response.Diagnostics.AddAttributeError(
+				request.AttributePath,
+				validator.Description(ctx),
+				fmt.Sprintf("%v must be defined and not empty for '%v' integration",
+					attributeToken,
+					snyk.GitLabIntegrationType,
+				),
+			)
+		}
+	}
+}
+
+func getAttributeValue(ctx context.Context, attrName string, request tfsdk.ValidateAttributeRequest) (types.String, diag.Diagnostics) {
+	attrPaths, diags := request.Config.PathMatches(ctx, path.MatchRoot(attrName))
+	if diags.HasError() {
+		return types.String{}, diags
+	}
+
+	var value types.String
+	diags = request.Config.GetAttribute(ctx, attrPaths[0], &value)
+	if diags.HasError() {
+		return types.String{}, diags
+	}
+
+	return value, nil
+}
+
+func AllowedIntegrationTypes() []string {
+	return []string{
+		snyk.ACRIntegrationType,
+		snyk.ArtifactoryCRIntegrationType,
+		snyk.AzureReposIntegrationType,
+		snyk.BitBucketCloudIntegrationType,
+		snyk.BitBucketConnectAppIntegrationType,
+		snyk.BitBucketServerIntegrationType,
+		snyk.DigitalOceanCRIntegrationType,
+		snyk.DockerHubIntegrationType,
+		snyk.ECRIntegrationType,
+		snyk.GCRIntegrationType,
+		snyk.GitHubIntegrationType,
+		snyk.GitHubCRIntegrationType,
+		snyk.GitHubEnterpriseIntegrationType,
+		snyk.GitLabIntegrationType,
+		snyk.GitLabCRIntegrationType,
+		snyk.GoogleArtifactCRIntegrationType,
+		snyk.HarborCRIntegrationType,
+		snyk.NexusCRIntegrationType,
+		snyk.QuayCRIntegrationType,
+	}
+}
+
+// RequiresConfiguredCredentials checks that a set of path.Expression match
+// specific integration type, e.g.
+//
+//   - type 'github' has token defined
+//   - type 'acr' has username, password and registryBase defined
+//
+// Full matrix can be found under attributes, see https://snyk.docs.apiary.io/#reference/integrations/integrations/add-new-integration
+func RequiresConfiguredCredentials() tfsdk.AttributeValidator {
+	return &requiredConfiguredCredentialsValidator{}
+}

--- a/internal/validator/credential_requires_configured_test.go
+++ b/internal/validator/credential_requires_configured_test.go
@@ -1,0 +1,175 @@
+package validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequiredConfiguredCredentialsValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		req      tfsdk.ValidateAttributeRequest
+		expected *tfsdk.ValidateAttributeResponse
+	}
+	tests := map[string]testCase{
+		"non-type_attribute": {
+			req: tfsdk.ValidateAttributeRequest{
+				AttributeConfig: types.String{Value: "test-value"},
+				Config: tfsdk.Config{
+					Schema: tfsdk.Schema{
+						Attributes: map[string]tfsdk.Attribute{
+							"test": {Optional: true, Type: types.StringType},
+						},
+					},
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"test": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"test": tftypes.NewValue(tftypes.String, "test-value"),
+						},
+					),
+				},
+			},
+			expected: &tfsdk.ValidateAttributeResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewAttributeErrorDiagnostic(
+						path.Path{},
+						"Ensure that integration is correctly configured",
+						"Validator must be applied for integration 'type' only.",
+					),
+				},
+			},
+		},
+		"type_attribute": {
+			req: tfsdk.ValidateAttributeRequest{
+				AttributeConfig:         types.String{Value: "type-value"},
+				AttributePath:           path.Root("type"),
+				AttributePathExpression: path.MatchRoot("type"),
+				Config: tfsdk.Config{
+					Schema: tfsdk.Schema{
+						Attributes: map[string]tfsdk.Attribute{
+							"type": {Optional: true, Type: types.StringType},
+						},
+					},
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"type": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"type": tftypes.NewValue(tftypes.String, "type-value"),
+						},
+					),
+				},
+			},
+			expected: &tfsdk.ValidateAttributeResponse{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := tfsdk.ValidateAttributeResponse{}
+
+			RequiresConfiguredCredentials().Validate(context.TODO(), test.req, &actual)
+
+			assert.Equal(t, test.expected.Diagnostics, actual.Diagnostics)
+		})
+	}
+}
+
+func TestRequiredConfiguredCredentialsValidator_github(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		req      tfsdk.ValidateAttributeRequest
+		expected *tfsdk.ValidateAttributeResponse
+	}
+	tests := map[string]testCase{
+		"with-token": {
+			req: tfsdk.ValidateAttributeRequest{
+				AttributeConfig:         types.String{Value: "github"},
+				AttributePath:           path.Root("type"),
+				AttributePathExpression: path.MatchRoot("type"),
+				Config: tfsdk.Config{
+					Schema: tfsdk.Schema{
+						Attributes: map[string]tfsdk.Attribute{
+							"type":  {Optional: true, Type: types.StringType},
+							"token": {Optional: true, Type: types.StringType},
+						},
+					},
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"type":  tftypes.String,
+								"token": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"type":  tftypes.NewValue(tftypes.String, "github"),
+							"token": tftypes.NewValue(tftypes.String, "github-token"),
+						},
+					),
+				},
+			},
+			expected: &tfsdk.ValidateAttributeResponse{},
+		},
+		"without-token": {
+			req: tfsdk.ValidateAttributeRequest{
+				AttributeConfig:         types.String{Value: "github"},
+				AttributePath:           path.Root("type"),
+				AttributePathExpression: path.MatchRoot("type"),
+				Config: tfsdk.Config{
+					Schema: tfsdk.Schema{
+						Attributes: map[string]tfsdk.Attribute{
+							"type":  {Optional: true, Type: types.StringType},
+							"token": {Optional: true, Type: types.StringType},
+						},
+					},
+					Raw: tftypes.NewValue(
+						tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"type":  tftypes.String,
+								"token": tftypes.String,
+							},
+						},
+						map[string]tftypes.Value{
+							"type":  tftypes.NewValue(tftypes.String, "github"),
+							"token": tftypes.NewValue(tftypes.String, ""),
+						},
+					),
+				},
+			},
+			expected: &tfsdk.ValidateAttributeResponse{
+				Diagnostics: diag.Diagnostics{
+					diag.NewAttributeErrorDiagnostic(
+						path.Root("type"),
+						"Ensure that integration is correctly configured",
+						"token must be defined and not empty for 'github' integration",
+					),
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := tfsdk.ValidateAttributeResponse{}
+
+			RequiresConfiguredCredentials().Validate(context.TODO(), test.req, &actual)
+
+			assert.Equal(t, test.expected.Diagnostics, actual.Diagnostics)
+		})
+	}
+}

--- a/internal/validator/string_not_empty.go
+++ b/internal/validator/string_not_empty.go
@@ -1,4 +1,4 @@
-package validators
+package validator
 
 import (
 	"context"

--- a/internal/validator/string_not_empty_test.go
+++ b/internal/validator/string_not_empty_test.go
@@ -1,4 +1,4 @@
-package validators
+package validator
 
 import (
 	"context"


### PR DESCRIPTION
This PR adds validators for `snyk_integration` resource:
- oneOf validator to ensure correct type
- credentials validator

Note, that no all credentials types are covered, atm only `acr`, `bitbucket-cloud`, `bitbucket-server`, `github` and `gitlab`.