### PR TITLE
docs: fix provider version in example snippet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     snyk = {
       source  = "pavel-snyk/snyk"
-      version = "~> 0.3"
+      version = "~> 0.6"
     }
   }
 }


### PR DESCRIPTION
This PR fixes failing documentation step and re-generated documentation with `make docs`.