### PR TITLE
refactor: rename pull_request_testing attribute

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -23,7 +23,7 @@ resource "snyk_integration" "gitlab" {
 }
 ```
 
-### Using Pull Request Testing
+### Using Pull Request SCA
 
 ```terraform
 resource "snyk_integration" "github" {
@@ -32,7 +32,7 @@ resource "snyk_integration" "github" {
   type  = "github"
   token = "rotated-github-secret-token"
 
-  pull_request_testing = {
+  pull_request_sca = {
     enabled = true
 
     fail_on_any_issue            = false
@@ -52,7 +52,7 @@ resource "snyk_integration" "github" {
 ### Optional
 
 - `password` (String, Sensitive) The password used by the integration.
-- `pull_request_testing` (Attributes) Pull request tests settings applied whenever a new PR is opened. (see [below for nested schema](#nestedatt--pull_request_testing))
+- `pull_request_sca` (Attributes) The pull request testing configuration for SCA (Software Composition Analysis). Snyk will checks projects imported through the SCM integration for security and license issues whenever a new PR is opened. (see [below for nested schema](#nestedatt--pull_request_sca))
 - `region` (String) The region used by the integration.
 - `registry_url` (String) The URL for container registries used by the integration (e.g. for ECR).
 - `role_arn` (String) The role ARN used by the integration (ECR only).
@@ -64,12 +64,12 @@ resource "snyk_integration" "github" {
 
 - `id` (String) The ID of the integration.
 
-<a id="nestedatt--pull_request_testing"></a>
-### Nested Schema for `pull_request_testing`
+<a id="nestedatt--pull_request_sca"></a>
+### Nested Schema for `pull_request_sca`
 
 Optional:
 
-- `enabled` (Boolean) Denotes the pull request testing feature should be enabled for this integration.
+- `enabled` (Boolean) Denotes the pull request SCA feature should be enabled for this integration.
 - `fail_on_any_issue` (Boolean) Fails an opened pull request if any vulnerable dependencies have been detected, otherwise the pull request should only fail when a dependency with issues is added.
 - `fail_only_for_high_and_critical_severity` (Boolean) Fails an opened pull request if any dependencies are marked as being of high or critical severity.
 - `fail_only_on_issues_with_fix` (Boolean) Fails an opened pull request only when issues found have a fix available.

--- a/examples/resources/snyk_integration/resource_with_pull_request_sca.tf
+++ b/examples/resources/snyk_integration/resource_with_pull_request_sca.tf
@@ -4,7 +4,7 @@ resource "snyk_integration" "github" {
   type  = "github"
   token = "rotated-github-secret-token"
 
-  pull_request_testing = {
+  pull_request_sca = {
     enabled = true
 
     fail_on_any_issue            = false

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -44,15 +44,16 @@ func (r integrationResourceType) GetSchema(_ context.Context) (tfsdk.Schema, dia
 				},
 				Type: types.StringType,
 			},
-			"pull_request_testing": {
-				Description: "Pull request tests settings applied whenever a new PR is opened.",
-				Optional:    true,
+			"pull_request_sca": {
+				Description: "The pull request testing configuration for SCA (Software Composition Analysis). Snyk will checks " +
+					"projects imported through the SCM integration for security and license issues whenever a new PR is opened.",
+				Optional: true,
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					resource.UseStateForUnknown(),
 				},
 				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 					"enabled": {
-						Description: "Denotes the pull request testing feature should be enabled for this integration.",
+						Description: "Denotes the pull request SCA feature should be enabled for this integration.",
 						Computed:    true,
 						Optional:    true,
 						PlanModifiers: tfsdk.AttributePlanModifiers{
@@ -61,9 +62,10 @@ func (r integrationResourceType) GetSchema(_ context.Context) (tfsdk.Schema, dia
 						Type: types.BoolType,
 					},
 					"fail_on_any_issue": {
-						Description: "Fails an opened pull request if any vulnerable dependencies have been detected, otherwise the pull request should only fail when a dependency with issues is added.",
-						Computed:    true,
-						Optional:    true,
+						Description: "Fails an opened pull request if any vulnerable dependencies have been detected, otherwise " +
+							"the pull request should only fail when a dependency with issues is added.",
+						Computed: true,
+						Optional: true,
 						PlanModifiers: tfsdk.AttributePlanModifiers{
 							resource.UseStateForUnknown(),
 						},
@@ -162,20 +164,20 @@ type integrationResource struct {
 }
 
 type integrationData struct {
-	ID                 types.String        `tfsdk:"id"`
-	OrganizationID     types.String        `tfsdk:"organization_id"`
-	Password           types.String        `tfsdk:"password"`
-	PullRequestTesting *pullRequestTesting `tfsdk:"pull_request_testing"`
-	Region             types.String        `tfsdk:"region"`
-	RegistryURL        types.String        `tfsdk:"registry_url"`
-	RoleARN            types.String        `tfsdk:"role_arn"`
-	Token              types.String        `tfsdk:"token"`
-	Type               types.String        `tfsdk:"type"`
-	URL                types.String        `tfsdk:"url"`
-	Username           types.String        `tfsdk:"username"`
+	ID             types.String    `tfsdk:"id"`
+	OrganizationID types.String    `tfsdk:"organization_id"`
+	Password       types.String    `tfsdk:"password"`
+	PullRequestSCA *pullRequestSCA `tfsdk:"pull_request_sca"`
+	Region         types.String    `tfsdk:"region"`
+	RegistryURL    types.String    `tfsdk:"registry_url"`
+	RoleARN        types.String    `tfsdk:"role_arn"`
+	Token          types.String    `tfsdk:"token"`
+	Type           types.String    `tfsdk:"type"`
+	URL            types.String    `tfsdk:"url"`
+	Username       types.String    `tfsdk:"username"`
 }
 
-type pullRequestTesting struct {
+type pullRequestSCA struct {
 	Enabled                            types.Bool `tfsdk:"enabled"`
 	FailOnAnyIssue                     types.Bool `tfsdk:"fail_on_any_issue"`
 	FailOnlyForHighAndCriticalSeverity types.Bool `tfsdk:"fail_only_for_high_and_critical_severity"`
@@ -265,13 +267,13 @@ func (r integrationResource) Create(ctx context.Context, request resource.Create
 		result.ID = types.String{Value: integration.ID}
 	}
 
-	if plan.PullRequestTesting != nil {
+	if plan.PullRequestSCA != nil {
 		updateRequest := &snyk.IntegrationSettingsUpdateRequest{
 			IntegrationSettings: &snyk.IntegrationSettings{
-				PullRequestTestEnabled:                        toBoolPtr(plan.PullRequestTesting.Enabled),
-				PullRequestFailOnAnyVulnerability:             toBoolPtr(plan.PullRequestTesting.FailOnAnyIssue),
-				PullRequestFailOnlyForHighAndCriticalSeverity: toBoolPtr(plan.PullRequestTesting.FailOnlyForHighAndCriticalSeverity),
-				PullRequestFailOnlyForIssuesWithFix:           toBoolPtr(plan.PullRequestTesting.FailOnlyOnIssuesWithFix),
+				PullRequestTestEnabled:                        toBoolPtr(plan.PullRequestSCA.Enabled),
+				PullRequestFailOnAnyVulnerability:             toBoolPtr(plan.PullRequestSCA.FailOnAnyIssue),
+				PullRequestFailOnlyForHighAndCriticalSeverity: toBoolPtr(plan.PullRequestSCA.FailOnlyForHighAndCriticalSeverity),
+				PullRequestFailOnlyForIssuesWithFix:           toBoolPtr(plan.PullRequestSCA.FailOnlyOnIssuesWithFix),
 			},
 		}
 
@@ -280,7 +282,7 @@ func (r integrationResource) Create(ctx context.Context, request resource.Create
 			response.Diagnostics.AddError("Error updating pull request settings", err.Error())
 			return
 		}
-		result.PullRequestTesting = &pullRequestTesting{
+		result.PullRequestSCA = &pullRequestSCA{
 			Enabled:                            fromBoolPtr(settings.PullRequestTestEnabled),
 			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyVulnerability),
 			FailOnlyForHighAndCriticalSeverity: fromBoolPtr(settings.PullRequestFailOnlyForHighAndCriticalSeverity),
@@ -311,20 +313,20 @@ func (r integrationResource) Read(ctx context.Context, request resource.ReadRequ
 		return
 	}
 
-	if state.PullRequestTesting != nil {
+	if state.PullRequestSCA != nil {
 		settings, _, err := r.p.client.Integrations.GetSettings(ctx, organizationID, integration.ID)
 		if err != nil {
 			response.Diagnostics.AddError("Error reading integration settings", err.Error())
 			return
 		}
 
-		pullRequestTesting := &pullRequestTesting{
+		pullRequestSCA := &pullRequestSCA{
 			Enabled:                            fromBoolPtr(settings.PullRequestTestEnabled),
 			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyVulnerability),
 			FailOnlyForHighAndCriticalSeverity: fromBoolPtr(settings.PullRequestFailOnlyForHighAndCriticalSeverity),
 			FailOnlyOnIssuesWithFix:            fromBoolPtr(settings.PullRequestFailOnlyForIssuesWithFix),
 		}
-		state.PullRequestTesting = pullRequestTesting
+		state.PullRequestSCA = pullRequestSCA
 	}
 
 	state.ID = types.String{Value: integration.ID}
@@ -367,13 +369,13 @@ func (r integrationResource) Update(ctx context.Context, request resource.Update
 		return
 	}
 
-	if plan.PullRequestTesting != nil {
+	if plan.PullRequestSCA != nil {
 		updateRequest := &snyk.IntegrationSettingsUpdateRequest{
 			IntegrationSettings: &snyk.IntegrationSettings{
-				PullRequestTestEnabled:                        toBoolPtr(plan.PullRequestTesting.Enabled),
-				PullRequestFailOnAnyVulnerability:             toBoolPtr(plan.PullRequestTesting.FailOnAnyIssue),
-				PullRequestFailOnlyForHighAndCriticalSeverity: toBoolPtr(plan.PullRequestTesting.FailOnlyForHighAndCriticalSeverity),
-				PullRequestFailOnlyForIssuesWithFix:           toBoolPtr(plan.PullRequestTesting.FailOnlyOnIssuesWithFix),
+				PullRequestTestEnabled:                        toBoolPtr(plan.PullRequestSCA.Enabled),
+				PullRequestFailOnAnyVulnerability:             toBoolPtr(plan.PullRequestSCA.FailOnAnyIssue),
+				PullRequestFailOnlyForHighAndCriticalSeverity: toBoolPtr(plan.PullRequestSCA.FailOnlyForHighAndCriticalSeverity),
+				PullRequestFailOnlyForIssuesWithFix:           toBoolPtr(plan.PullRequestSCA.FailOnlyOnIssuesWithFix),
 			},
 		}
 
@@ -382,7 +384,7 @@ func (r integrationResource) Update(ctx context.Context, request resource.Update
 			response.Diagnostics.AddError("Error updating pull request settings", err.Error())
 			return
 		}
-		plan.PullRequestTesting = &pullRequestTesting{
+		plan.PullRequestSCA = &pullRequestSCA{
 			Enabled:                            fromBoolPtr(settings.PullRequestTestEnabled),
 			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyVulnerability),
 			FailOnlyForHighAndCriticalSeverity: fromBoolPtr(settings.PullRequestFailOnlyForHighAndCriticalSeverity),

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -35,14 +35,14 @@ func TestAccResourceIntegration_basic(t *testing.T) {
 					testAccCheckResourceIntegrationExists("snyk_integration.test", organizationName, &integration),
 					resource.TestCheckResourceAttrSet("snyk_integration.test", "id"),
 					resource.TestCheckResourceAttr("snyk_integration.test", "type", "gitlab"),
-					resource.TestCheckNoResourceAttr("snyk_integration.test", "pull_request_testing.enabled"),
+					resource.TestCheckNoResourceAttr("snyk_integration.test", "pull_request_sca.enabled"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccResourceIntegration_pullRequestTesting(t *testing.T) {
+func TestAccResourceIntegration_pullRequestSCA(t *testing.T) {
 	t.Parallel()
 
 	var integration snyk.Integration
@@ -55,12 +55,12 @@ func TestAccResourceIntegration_pullRequestTesting(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceIntegrationConfigWithPullRequestTesting(organizationName, groupID, token),
+				Config: testAccResourceIntegrationConfigWithPullRequestSCA(organizationName, groupID, token),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourceIntegrationExists("snyk_integration.test", organizationName, &integration),
-					resource.TestCheckResourceAttrSet("snyk_integration.test", "pull_request_testing.enabled"),
-					resource.TestCheckResourceAttr("snyk_integration.test", "pull_request_testing.fail_on_any_issue", "true"),
-					resource.TestCheckResourceAttr("snyk_integration.test", "pull_request_testing.fail_only_on_issues_with_fix", "false"),
+					resource.TestCheckResourceAttrSet("snyk_integration.test", "pull_request_sca.enabled"),
+					resource.TestCheckResourceAttr("snyk_integration.test", "pull_request_sca.fail_on_any_issue", "true"),
+					resource.TestCheckResourceAttr("snyk_integration.test", "pull_request_sca.fail_only_on_issues_with_fix", "false"),
 				),
 			},
 		},
@@ -128,7 +128,7 @@ resource "snyk_integration" "test" {
 `, organizationName, groupID, token)
 }
 
-func testAccResourceIntegrationConfigWithPullRequestTesting(organizationName, groupID, token string) string {
+func testAccResourceIntegrationConfigWithPullRequestSCA(organizationName, groupID, token string) string {
 	return fmt.Sprintf(`
 resource "snyk_organization" "test" {
   name = "%s"
@@ -141,7 +141,7 @@ resource "snyk_integration" "test" {
   url   = "https://testing.gitlab.local"
   token = "%s"
 
-  pull_request_testing = {
+  pull_request_sca = {
     enabled = true
 
     fail_on_any_issue            = true

--- a/templates/resources/integration.md.tmpl
+++ b/templates/resources/integration.md.tmpl
@@ -16,8 +16,8 @@ description: |-
 
 {{ tffile "examples/resources/snyk_integration/resource_default.tf" }}
 
-### Using Pull Request Testing
+### Using Pull Request SCA
 
-{{ tffile "examples/resources/snyk_integration/resource_with_pull_request_testing.tf" }}
+{{ tffile "examples/resources/snyk_integration/resource_with_pull_request_sca.tf" }}
 
 {{ .SchemaMarkdown | trimspace }}


### PR DESCRIPTION
This PR renames `pull_request_testing` attribute to `pull_request_sca`.

Because we have different configuration for SCA (Software Composition Analysis) and SAST (Static Application Security Testing), we should use more explicit naming to avoid any confusion.