### PR TITLE
chore: update snyk-sdk-go to v0.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
-	github.com/pavel-snyk/snyk-sdk-go v0.3.1
+	github.com/pavel-snyk/snyk-sdk-go v0.4.0
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/pavel-snyk/snyk-sdk-go v0.3.1 h1:RechIZ/uzShWUDkEzgt5Bu3CCLeg7q/I09AWBL9uhHQ=
-github.com/pavel-snyk/snyk-sdk-go v0.3.1/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
+github.com/pavel-snyk/snyk-sdk-go v0.4.0 h1:WwUI2NRNnNYJgSuubwbLqlFXl0xHJ2qbRgxf2mfiVPo=
+github.com/pavel-snyk/snyk-sdk-go v0.4.0/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/provider/resource_integration.go
+++ b/internal/provider/resource_integration.go
@@ -271,7 +271,7 @@ func (r integrationResource) Create(ctx context.Context, request resource.Create
 		updateRequest := &snyk.IntegrationSettingsUpdateRequest{
 			IntegrationSettings: &snyk.IntegrationSettings{
 				PullRequestTestEnabled:                        toBoolPtr(plan.PullRequestSCA.Enabled),
-				PullRequestFailOnAnyVulnerability:             toBoolPtr(plan.PullRequestSCA.FailOnAnyIssue),
+				PullRequestFailOnAnyIssue:                     toBoolPtr(plan.PullRequestSCA.FailOnAnyIssue),
 				PullRequestFailOnlyForHighAndCriticalSeverity: toBoolPtr(plan.PullRequestSCA.FailOnlyForHighAndCriticalSeverity),
 				PullRequestFailOnlyForIssuesWithFix:           toBoolPtr(plan.PullRequestSCA.FailOnlyOnIssuesWithFix),
 			},
@@ -284,7 +284,7 @@ func (r integrationResource) Create(ctx context.Context, request resource.Create
 		}
 		result.PullRequestSCA = &pullRequestSCA{
 			Enabled:                            fromBoolPtr(settings.PullRequestTestEnabled),
-			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyVulnerability),
+			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyIssue),
 			FailOnlyForHighAndCriticalSeverity: fromBoolPtr(settings.PullRequestFailOnlyForHighAndCriticalSeverity),
 			FailOnlyOnIssuesWithFix:            fromBoolPtr(settings.PullRequestFailOnlyForIssuesWithFix),
 		}
@@ -322,7 +322,7 @@ func (r integrationResource) Read(ctx context.Context, request resource.ReadRequ
 
 		pullRequestSCA := &pullRequestSCA{
 			Enabled:                            fromBoolPtr(settings.PullRequestTestEnabled),
-			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyVulnerability),
+			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyIssue),
 			FailOnlyForHighAndCriticalSeverity: fromBoolPtr(settings.PullRequestFailOnlyForHighAndCriticalSeverity),
 			FailOnlyOnIssuesWithFix:            fromBoolPtr(settings.PullRequestFailOnlyForIssuesWithFix),
 		}
@@ -373,7 +373,7 @@ func (r integrationResource) Update(ctx context.Context, request resource.Update
 		updateRequest := &snyk.IntegrationSettingsUpdateRequest{
 			IntegrationSettings: &snyk.IntegrationSettings{
 				PullRequestTestEnabled:                        toBoolPtr(plan.PullRequestSCA.Enabled),
-				PullRequestFailOnAnyVulnerability:             toBoolPtr(plan.PullRequestSCA.FailOnAnyIssue),
+				PullRequestFailOnAnyIssue:                     toBoolPtr(plan.PullRequestSCA.FailOnAnyIssue),
 				PullRequestFailOnlyForHighAndCriticalSeverity: toBoolPtr(plan.PullRequestSCA.FailOnlyForHighAndCriticalSeverity),
 				PullRequestFailOnlyForIssuesWithFix:           toBoolPtr(plan.PullRequestSCA.FailOnlyOnIssuesWithFix),
 			},
@@ -386,7 +386,7 @@ func (r integrationResource) Update(ctx context.Context, request resource.Update
 		}
 		plan.PullRequestSCA = &pullRequestSCA{
 			Enabled:                            fromBoolPtr(settings.PullRequestTestEnabled),
-			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyVulnerability),
+			FailOnAnyIssue:                     fromBoolPtr(settings.PullRequestFailOnAnyIssue),
 			FailOnlyForHighAndCriticalSeverity: fromBoolPtr(settings.PullRequestFailOnlyForHighAndCriticalSeverity),
 			FailOnlyOnIssuesWithFix:            fromBoolPtr(settings.PullRequestFailOnlyForIssuesWithFix),
 		}


### PR DESCRIPTION
This PR updates `snyk-sdk-go` to v0.4.0 (contains changes for dependency auto-upgrade).