### PR TITLE
chore: do not run acceptance tests in parallel

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,6 +75,7 @@ jobs:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         terraform-version:
           - "1.0.*"

--- a/internal/provider/resource_integration_test.go
+++ b/internal/provider/resource_integration_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestAccResourceIntegration_basic(t *testing.T) {
-	t.Parallel()
-
 	var integration snyk.Integration
 	organizationName := fmt.Sprintf("tf-test-acc_%s", acctest.RandString(10))
 	groupID := os.Getenv("SNYK_GROUP_ID")
@@ -43,8 +41,6 @@ func TestAccResourceIntegration_basic(t *testing.T) {
 }
 
 func TestAccResourceIntegration_pullRequestSCA(t *testing.T) {
-	t.Parallel()
-
 	var integration snyk.Integration
 	organizationName := fmt.Sprintf("tf-test-acc_%s", acctest.RandString(10))
 	groupID := os.Getenv("SNYK_GROUP_ID")

--- a/internal/provider/resource_organization_test.go
+++ b/internal/provider/resource_organization_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestAccResourceOrganization_basic(t *testing.T) {
-	t.Parallel()
-
 	var organization snyk.Organization
 	organizationName := fmt.Sprintf("tf-test-acc_%s", acctest.RandString(10))
 	groupID := os.Getenv("SNYK_GROUP_ID")


### PR DESCRIPTION
Because of API v1 restriction and parallel calls one of three `make testacc` runs fails every time. Using API v3 should fix it in the future 🤞.