### PR TITLE
chore: upgrade snyk-sdk-go to v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.14.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
-	github.com/pavel-snyk/snyk-sdk-go v0.4.1-0.20220920001418-509f733346d6
+	github.com/pavel-snyk/snyk-sdk-go v0.4.1
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLA
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/pavel-snyk/snyk-sdk-go v0.4.1-0.20220920001418-509f733346d6 h1:i/BLcm5+VkkXclUaJZ2X8eRyA0zylrg3n3OHqa0pom4=
-github.com/pavel-snyk/snyk-sdk-go v0.4.1-0.20220920001418-509f733346d6/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
+github.com/pavel-snyk/snyk-sdk-go v0.4.1 h1:ALtE4Xek8fkOEazz3vDZu9TJgoggAn9mRnyDaaqa0/E=
+github.com/pavel-snyk/snyk-sdk-go v0.4.1/go.mod h1:LRL1TRuuM925gnyGp54WtS9p8S4yJMd0oS4JpLg+n7Y=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Bump snyk-sdk-go to latest tag.