### PR TITLE
chore: fix goreleaser deprecated options

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -4,6 +4,7 @@ archives:
       - README.md
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    rlcp: true
 
 before:
   hooks:
@@ -14,15 +15,15 @@ builds:
     flags:
       - -trimpath
     goarch:
-      - amd64
       - '386'
+      - amd64
       - arm
       - arm64
     goos:
-      - freebsd
-      - windows
-      - linux
       - darwin
+      - freebsd
+      - linux
+      - windows
     ignore:
       - goos: darwin
         goarch: '386'
@@ -57,4 +58,4 @@ release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  draft: true
+  draft: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          args: release --config .github/goreleaser.yaml --rm-dist --release-notes=.release/DRAFT.md
+          args: release --config .github/goreleaser.yaml --clean --release-notes=.release/DRAFT.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,6 +81,7 @@ jobs:
           - "1.0.*"
           - "1.1.*"
           - "1.2.*"
+          - "1.3.*"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR bumps all GitHub actions to the latest version and fix deprecated usage of GoReleaser options.