### PR TITLE
chore(datasource/snyk organization): add acceptance tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,8 @@ linters:
       rules:
         main:
           list-mode: lax
+          allow:
+            - 'github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry'
           deny:
             - pkg: "github.com/hashicorp/terraform-plugin-sdk/v2" # prefix
               desc: "Use Terraform Plugin Framework"

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/pavel-snyk/snyk-sdk-go/v2 v2.0.0-20260211181057-d3133137dff8
+	github.com/pavel-snyk/snyk-sdk-go/v2 v2.0.0-20260213023010-4fe5d6db23ef
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/pavel-snyk/snyk-sdk-go/v2 v2.0.0-20260211181057-d3133137dff8 h1:1IIR7PHXT8DOxaG3QlaBtSWPM/RZEImELju2OVULQGk=
-github.com/pavel-snyk/snyk-sdk-go/v2 v2.0.0-20260211181057-d3133137dff8/go.mod h1:7E28mxL/T/EA3hMo9Fa0FjYuLDq0uUKJFB05oaaPoog=
+github.com/pavel-snyk/snyk-sdk-go/v2 v2.0.0-20260213023010-4fe5d6db23ef h1:ZwWjYcXjNx0dz8hX9wzTwZTj9lP+urM3ilXOnvGL1vo=
+github.com/pavel-snyk/snyk-sdk-go/v2 v2.0.0-20260213023010-4fe5d6db23ef/go.mod h1:7E28mxL/T/EA3hMo9Fa0FjYuLDq0uUKJFB05oaaPoog=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/provider/data_source_organization_test.go
+++ b/internal/provider/data_source_organization_test.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccSnykOrganizationDataSource(t *testing.T) {
+	t.Parallel()
+
+	name := acctest.RandomWithPrefix(accTestPrefix)
+	groupID := accTestGroupID()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: testAccSnykOrganizationDataSourceConfig(name, groupID),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.snyk_organization.test",
+						tfjsonpath.New("group_id"),
+						knownvalue.StringExact(groupID),
+					),
+					statecheck.ExpectKnownValue(
+						"data.snyk_organization.test",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.snyk_organization.test",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(name),
+					),
+					statecheck.ExpectKnownValue(
+						"data.snyk_organization.test",
+						tfjsonpath.New("slug"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.snyk_organization.test",
+						tfjsonpath.New("tenant_id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccSnykOrganizationDataSource_expectError(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSnykOrganizationDataSourceConfigWithoutIDAndName,
+				ExpectError: regexp.MustCompile(`The attribute "id" or "name" must be defined`),
+			},
+		},
+	})
+}
+
+func testAccSnykOrganizationDataSourceConfig(name, groupID string) string {
+	return fmt.Sprintf(`
+data "snyk_organization" "test" {
+  id = snyk_organization.test.id
+}
+
+resource "snyk_organization" "test" {
+  name     = %[1]q
+  group_id = %[2]q
+}
+`, name, groupID)
+}
+
+const testAccSnykOrganizationDataSourceConfigWithoutIDAndName = `
+data "snyk_organization" "test" {}
+`

--- a/internal/provider/helper/organization_status.go
+++ b/internal/provider/helper/organization_status.go
@@ -1,0 +1,35 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/pavel-snyk/snyk-sdk-go/v2/snyk"
+)
+
+const (
+	organizationTenantIDPopulated    = "tenantIDPopulated"
+	organizationTenantIDNotPopulated = "tenantIDNotPopulated"
+)
+
+func statusOrganizationTenantIDPopulatedState(ctx context.Context, client *snyk.Client, orgID string) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		organization, _, err := client.Orgs.Get(ctx, orgID, nil)
+		if err != nil {
+			return nil, "", err
+		}
+		if organization == nil {
+			return nil, "", fmt.Errorf("failed to get organization with id: %s", orgID)
+		}
+
+		if organization.Relationships != nil &&
+			organization.Relationships.Tenant != nil &&
+			organization.Relationships.Tenant.Data != nil &&
+			organization.Relationships.Tenant.Data.ID != "" {
+			return organization, organizationTenantIDPopulated, nil
+		}
+
+		return organization, organizationTenantIDNotPopulated, nil
+	}
+}

--- a/internal/provider/helper/organization_wait.go
+++ b/internal/provider/helper/organization_wait.go
@@ -1,0 +1,26 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/pavel-snyk/snyk-sdk-go/v2/snyk"
+)
+
+func WaitOrganizationTenantIDPopulated(ctx context.Context, client *snyk.Client, orgID string) error {
+	stateConf := &retry.StateChangeConf{
+		Pending:    []string{organizationTenantIDNotPopulated},
+		Target:     []string{organizationTenantIDPopulated},
+		Timeout:    10 * time.Minute,
+		MinTimeout: 5 * time.Second,
+		Delay:      3 * time.Second,
+		Refresh:    statusOrganizationTenantIDPopulatedState(ctx, client, orgID),
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("failed to wait for organization (%s) to become tenant_id set: %w", orgID, err)
+	}
+	return nil
+}

--- a/internal/provider/resource_organization.go
+++ b/internal/provider/resource_organization.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pavel-snyk/snyk-sdk-go/v2/snyk"
+
 	"github.com/pavel-snyk/terraform-provider-snyk/internal/provider/helper"
 )
 


### PR DESCRIPTION
This PR adds acceptance tests for `snyk_organization` datasource and fixes the issue with waiting for tenant provisioning.