### PR TITLE
fix(tools): adjust path to git-chglog in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Generate changelog
         run: |
-          git-chglog --config .github/changelog/config.yaml --output .release/DRAFT.md $(git describe --tags $(git rev-list --tags --max-count=1))
+          tools/bin/git-chglog --config .github/changelog/config.yaml --output .release/DRAFT.md $(git describe --tags $(git rev-list --tags --max-count=1))
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
This PR fixes issue with `git-chglog: command not found` error in release workflow, after all tools are installed locally (under tools/bin) instead of global GOBIN.